### PR TITLE
refactor: 移除二次等待，直接查询元素判定会员状态

### DIFF
--- a/Bilibili-Auto-Quality-Beta.user.js
+++ b/Bilibili-Auto-Quality-Beta.user.js
@@ -1795,29 +1795,19 @@
             return;
         }
 
-        try {
-            const [vipElement, currentQualityEl] = await Promise.all([
-                waitForElement(() => document.querySelector(".bili-avatar-icon.bili-avatar-right-icon.bili-avatar-icon-big-vip"), 3000),
-                waitForElement(() => document.querySelector(".bpx-player-ctrl-quality-menu-item.bpx-state-active .bpx-player-ctrl-quality-text"), 3000)
-            ]);
+        // Directly query elements as the higher-level observer has already waited for them
+        const vipElement = document.querySelector(".bili-avatar-icon.bili-avatar-right-icon.bili-avatar-icon-big-vip");
+        const currentQualityEl = document.querySelector(".bpx-player-ctrl-quality-menu-item.bpx-state-active .bpx-player-ctrl-quality-text");
 
-            state.isVipUser = vipElement !== null || (currentQualityEl && currentQualityEl.textContent.includes("大会员"));
-            state.vipStatusChecked = true;
-            // 缓存结果
-            state.sessionCache.vipStatus = state.isVipUser;
-            state.sessionCache.vipChecked = true;
+        state.isVipUser = vipElement !== null || (currentQualityEl && currentQualityEl.textContent.includes("大会员"));
+        state.vipStatusChecked = true;
+        // 缓存结果
+        state.sessionCache.vipStatus = state.isVipUser;
+        state.sessionCache.vipChecked = true;
 
-            console.log("[会员状态] 用户会员状态:", state.isVipUser ? "是" : "否");
-            if (state.isVipUser) {
-                console.log("[会员状态] 判定依据:", vipElement ? "发现会员图标" : "当前使用会员画质");
-            }
-        } catch (error) {
-            console.log("[会员状态] 检查超时，默认为非会员用户");
-            state.isVipUser = false;
-            state.vipStatusChecked = true;
-            // 缓存结果
-            state.sessionCache.vipStatus = state.isVipUser;
-            state.sessionCache.vipChecked = true;
+        console.log("[会员状态] 用户会员状态:", state.isVipUser ? "是" : "否");
+        if (state.isVipUser) {
+            console.log("[会员状态] 判定依据:", vipElement ? "发现会员图标" : "当前使用会员画质");
         }
     }
 


### PR DESCRIPTION
**修改**
上面已有“播放器/头像”观察与退避逻辑，当前函数内再次等待会造成重复与超时。移除大会员状态判定中的二次等待，改为在上层放行后直接 `querySelector` 所需元素，减少冗余等待与定时器开销，这样可以减少不必要的异步等待。

**有可能的影响**

正常情况下无功能变化，但在极慢加载时，大会员图标可能晚于首次检查出现，导致当次会话被缓存为非会员。

后续可以优化一下：当首判为非会员时，延时 10–15s 复查一次；若发现大会员元素则更新 `state.isVipUser=true` 并触发一次画质重选。